### PR TITLE
Modification to use CoinMarketCap with API, RegExp, and some common Variables

### DIFF
--- a/Cryptometer-Medium.ini
+++ b/Cryptometer-Medium.ini
@@ -29,6 +29,8 @@ LeftPadding=10
 TopPadding=10
 RowHeight=24
 AutoBorder=1
+APIKey=YOUR-API-GOES-HERE
+RegEx=(?siU)"price": (\d*\.\d{0,2}?).*percent_change_1h": ([-+]?\d*\.\d{0,2}?).*percent_change_24h": ([-+]?\d*\.\d{0,2}?).*percent_change_7d": ([-+]?\d*\.\d{0,2}?)
 
 # Adjusts the distance columns are from the left of the widget
 ColumnValueLeftPadding=(#LeftPadding#+50)
@@ -74,8 +76,9 @@ Text=7d
 [MeasureBTC]
 Measure=Plugin
 Plugin=WebParser
-URL=https://api.coinmarketcap.com/v1/ticker/bitcoin/
-RegExp=(?siU)price_usd": "(.*)".*percent_change_1h": "(.*)".*percent_change_24h": "(.*)".*percent_change_7d": "(.*)"
+URL=https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest?symbol=BTC
+RegExp=#RegEx#
+Header=X-CMC_PRO_API_KEY: #APIKey#
 UpdateRate=900 # every 15 minutes
 
 # Extract each column's value by the index
@@ -157,8 +160,9 @@ Text=%1%
 [MeasureETH]
 Measure=Plugin
 Plugin=WebParser
-URL=https://api.coinmarketcap.com/v1/ticker/ethereum/
-RegExp=(?siU)price_usd": "(.*)".*percent_change_1h": "(.*)".*percent_change_24h": "(.*)".*percent_change_7d": "(.*)"
+URL=https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest?symbol=ETH
+RegExp=#RegEx#
+Header=X-CMC_PRO_API_KEY: #APIKey#
 UpdateRate=900 # every 15 minutes
 
 # Extract each column's value by the index
@@ -240,8 +244,9 @@ Text=%1%
 [MeasureBCH]
 Measure=Plugin
 Plugin=WebParser
-URL=https://api.coinmarketcap.com/v1/ticker/bitcoin-cash/
-RegExp=(?siU)price_usd": "(.*)".*percent_change_1h": "(.*)".*percent_change_24h": "(.*)".*percent_change_7d": "(.*)"
+URL=https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest?symbol=BCH
+RegExp=#RegEx#
+Header=X-CMC_PRO_API_KEY: #APIKey#
 UpdateRate=900 # every 15 minutes
 
 # Extract each column's value by the index
@@ -323,8 +328,9 @@ Text=%1%
 [MeasureXRP]
 Measure=Plugin
 Plugin=WebParser
-URL=https://api.coinmarketcap.com/v1/ticker/ripple/
-RegExp=(?siU)price_usd": "(.*)".*percent_change_1h": "(.*)".*percent_change_24h": "(.*)".*percent_change_7d": "(.*)"
+URL=https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest?symbol=XRP
+RegExp=#RegEx#
+Header=X-CMC_PRO_API_KEY: #APIKey#
 UpdateRate=900 # every 15 minutes
 
 # Extract each column's value by the index
@@ -406,8 +412,9 @@ Text=%1%
 [MeasureLTC]
 Measure=Plugin
 Plugin=WebParser
-URL=https://api.coinmarketcap.com/v1/ticker/litecoin/
-RegExp=(?siU)price_usd": "(.*)".*percent_change_1h": "(.*)".*percent_change_24h": "(.*)".*percent_change_7d": "(.*)"
+URL=https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest?symbol=LTC
+RegExp=#RegEx#
+Header=X-CMC_PRO_API_KEY: #APIKey#
 UpdateRate=900 # every 15 minutes
 
 # Extract each column's value by the index


### PR DESCRIPTION
Addresses #10, #5, and #9. Chiefly, each GET from the API needs to have the API provided in the header. PR adds variable location for you to place your API key to connect to CoinMarketCap instead of placing this in each section. Also updated URLs for CoinMarketCap's Pro API (not as a variable), and updated the regular expressions to pull the data correctly from the API as a variable. On second thought perhaps the URL should also be a variable but oh well.