### PR TITLE
API Spaces Fix

### DIFF
--- a/Cryptometer-Medium.ini
+++ b/Cryptometer-Medium.ini
@@ -30,7 +30,7 @@ TopPadding=10
 RowHeight=24
 AutoBorder=1
 APIKey=YOUR-API-GOES-HERE
-RegEx=(?siU)"price": (\d*\.\d{0,2}?).*percent_change_1h": ([-+]?\d*\.\d{0,2}?).*percent_change_24h": ([-+]?\d*\.\d{0,2}?).*percent_change_7d": ([-+]?\d*\.\d{0,2}?)
+RegEx=(?siU)"price".*(\d*\.\d{0,2}?).*"percent_change_1h".*([-+]?\d*\.\d{0,2}?).*"percent_change_24h".*([-+]?\d*\.\d{0,2}?).*"percent_change_7d".*([-+]?\d*\.\d{0,2}?)
 
 # Adjusts the distance columns are from the left of the widget
 ColumnValueLeftPadding=(#LeftPadding#+50)


### PR DESCRIPTION
Looks like a recent CoinMarketCap API update inserted a couple spaces into the JSON response. This adjustment to the regex pattern will fix it.